### PR TITLE
Add light mode toggle and theme styling updates

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -5,9 +5,102 @@
   color-scheme: dark;
   --background: #050112;
   --foreground: #f6f7ff;
+  --body-background:
+    radial-gradient(circle at 12% 5%, rgba(255, 119, 214, 0.28), transparent 55%),
+    radial-gradient(circle at 88% -10%, rgba(59, 130, 246, 0.32), transparent 55%),
+    radial-gradient(circle at 45% 110%, rgba(34, 211, 238, 0.16), transparent 70%),
+    linear-gradient(180deg, #040014 0%, #05021a 45%, #06031f 100%);
+  --body-before-background:
+    radial-gradient(circle at 20% 30%, rgba(255, 120, 216, 0.55), transparent 75%),
+    radial-gradient(circle at 70% 65%, rgba(56, 189, 248, 0.45), transparent 80%);
+  --body-before-opacity: 0.8;
+  --body-after-background:
+    linear-gradient(0deg, rgba(210, 218, 255, 0.3) 1.35px, transparent 0),
+    linear-gradient(90deg, rgba(210, 218, 255, 0.3) 1.35px, transparent 0),
+    radial-gradient(circle, rgba(148, 163, 184, 0.28) 1px, transparent 0);
+  --body-after-opacity: 0.1;
+  --body-after-mix-blend: screen;
+  --header-panel-bg: rgba(15, 10, 36, 0.72);
+  --header-panel-border: rgba(255, 255, 255, 0.25);
+  --header-panel-shadow: 0 55px 110px -65px rgba(244, 114, 182, 0.75);
+  --header-halo: radial-gradient(circle at top, rgba(244, 114, 182, 0.45), transparent 65%);
+  --header-glint: linear-gradient(to right, rgba(255, 255, 255, 0.2), transparent, rgba(255, 255, 255, 0.2));
+  --header-nav-bg: transparent;
+  --header-nav-text: rgba(248, 232, 255, 0.95);
+  --header-nav-hover-text: #ffffff;
+  --header-nav-hover-bg: linear-gradient(120deg, rgba(244, 114, 182, 0.25), rgba(56, 189, 248, 0.25));
+  --header-initials-bg: rgba(255, 255, 255, 0.1);
+  --header-initials-text: #f6f7ff;
+  --header-brand-name: #ffffff;
+  --header-brand-title: rgba(244, 165, 252, 0.85);
+  --header-cta-border: rgba(255, 255, 255, 0.35);
+  --header-cta-bg: linear-gradient(120deg, rgba(244, 114, 182, 0.25), transparent 45%, rgba(56, 189, 248, 0.25));
+  --header-cta-text: #ffffff;
+  --header-cta-hover-border: rgba(255, 255, 255, 0.55);
+  --header-cta-hover-text: #ffffff;
+  --header-cta-hover-bg: linear-gradient(120deg, rgba(244, 114, 182, 0.35), transparent 45%, rgba(56, 189, 248, 0.3));
+  --header-cta-shadow: 0 40px 95px -60px rgba(244, 114, 182, 0.75);
+  --header-cta-hover-shadow: 0 48px 110px -60px rgba(56, 189, 248, 0.6);
+  --header-toggle-bg: rgba(255, 255, 255, 0.08);
+  --header-toggle-border: rgba(255, 255, 255, 0.35);
+  --header-toggle-text: rgba(245, 238, 255, 0.95);
+  --header-toggle-hover-bg: rgba(255, 255, 255, 0.15);
+  --header-toggle-hover-border: rgba(255, 255, 255, 0.55);
   --font-sans: "Sora", "Inter", "Helvetica Neue", Arial, sans-serif;
   --font-display: "Bricolage Grotesque", "Sora", "Inter", "Helvetica Neue", Arial, sans-serif;
   --font-mono: "IBM Plex Mono", "SFMono-Regular", "Menlo", monospace;
+}
+
+:root[data-theme="light"] {
+  color-scheme: light;
+  --background: #f9f5ff;
+  --foreground: #20123f;
+  --body-background:
+    radial-gradient(circle at 12% 5%, rgba(244, 189, 255, 0.55), transparent 58%),
+    radial-gradient(circle at 88% -10%, rgba(191, 219, 254, 0.55), transparent 55%),
+    radial-gradient(circle at 45% 110%, rgba(167, 243, 208, 0.35), transparent 70%),
+    linear-gradient(180deg, #fef7ff 0%, #f7edff 45%, #f1e6ff 100%);
+  --body-before-background:
+    radial-gradient(circle at 18% 32%, rgba(244, 143, 215, 0.75), transparent 78%),
+    radial-gradient(circle at 72% 68%, rgba(96, 165, 250, 0.6), transparent 82%);
+  --body-before-opacity: 0.92;
+  --body-after-background:
+    linear-gradient(0deg, rgba(147, 181, 255, 0.28) 1.35px, transparent 0),
+    linear-gradient(90deg, rgba(147, 181, 255, 0.28) 1.35px, transparent 0),
+    radial-gradient(circle, rgba(209, 196, 255, 0.35) 1px, transparent 0);
+  --body-after-opacity: 0.22;
+  --body-after-mix-blend: multiply;
+  --header-panel-bg: rgba(255, 255, 255, 0.9);
+  --header-panel-border: rgba(168, 85, 247, 0.35);
+  --header-panel-shadow: 0 45px 90px -55px rgba(147, 112, 219, 0.35);
+  --header-halo: radial-gradient(circle at top, rgba(254, 240, 255, 0.95), transparent 65%);
+  --header-glint: linear-gradient(to right, rgba(255, 255, 255, 0.85), rgba(244, 208, 255, 0.45), rgba(222, 242, 254, 0.6));
+  --header-nav-bg: rgba(255, 255, 255, 0.65);
+  --header-nav-text: #2a1655;
+  --header-nav-hover-text: #140a2d;
+  --header-nav-hover-bg: linear-gradient(120deg, rgba(236, 233, 255, 0.95), rgba(216, 242, 254, 0.85));
+  --header-initials-bg: rgba(238, 232, 255, 0.95);
+  --header-initials-text: #2f1557;
+  --header-brand-name: #1e0f3f;
+  --header-brand-title: #51367c;
+  --header-cta-border: rgba(147, 112, 219, 0.45);
+  --header-cta-bg: linear-gradient(135deg, rgba(252, 231, 243, 0.96), rgba(219, 234, 254, 0.96));
+  --header-cta-text: #210f3f;
+  --header-cta-hover-border: rgba(124, 58, 237, 0.55);
+  --header-cta-hover-text: #14072c;
+  --header-cta-hover-bg: linear-gradient(135deg, rgba(248, 217, 255, 0.98), rgba(191, 219, 254, 0.98));
+  --header-cta-shadow: 0 35px 70px -45px rgba(147, 112, 219, 0.45);
+  --header-cta-hover-shadow: 0 45px 80px -45px rgba(99, 102, 241, 0.45);
+  --header-toggle-bg: rgba(255, 255, 255, 0.96);
+  --header-toggle-border: rgba(147, 112, 219, 0.45);
+  --header-toggle-text: #2c1555;
+  --header-toggle-hover-bg: rgba(224, 231, 255, 0.92);
+  --header-toggle-hover-border: rgba(99, 102, 241, 0.55);
+  --light-text-primary: #20123f;
+  --light-text-secondary: #36255f;
+  --light-text-muted: #5b4b80;
+  --light-accent-pink: #a21caf;
+  --light-accent-emerald: #047857;
 }
 
 html {
@@ -35,16 +128,13 @@ html {
 body {
   margin: 0;
   min-height: 100vh;
-  background:
-    radial-gradient(circle at 12% 5%, rgba(255, 119, 214, 0.28), transparent 55%),
-    radial-gradient(circle at 88% -10%, rgba(59, 130, 246, 0.32), transparent 55%),
-    radial-gradient(circle at 45% 110%, rgba(34, 211, 238, 0.16), transparent 70%),
-    linear-gradient(180deg, #040014 0%, #05021a 45%, #06031f 100%);
+  background: var(--body-background);
   color: var(--foreground);
   font-family: var(--font-sans);
   letter-spacing: -0.01em;
   position: relative;
   overflow-x: hidden;
+  transition: background 0.6s ease, color 0.4s ease;
 }
 
 body::before {
@@ -56,12 +146,10 @@ body::before {
   width: 620px;
   margin-inline: auto;
   border-radius: 9999px;
-  background:
-    radial-gradient(circle at 20% 30%, rgba(255, 120, 216, 0.55), transparent 75%),
-    radial-gradient(circle at 70% 65%, rgba(56, 189, 248, 0.45), transparent 80%);
+  background: var(--body-before-background);
   filter: blur(160px);
   pointer-events: none;
-  opacity: 0.8;
+  opacity: var(--body-before-opacity);
   z-index: -2;
 }
 
@@ -70,14 +158,11 @@ body::after {
   position: fixed;
   inset: 0;
   pointer-events: none;
-  background-image:
-    linear-gradient(0deg, rgba(210, 218, 255, 0.3) 1.35px, transparent 0),
-    linear-gradient(90deg, rgba(210, 218, 255, 0.3) 1.35px, transparent 0),
-    radial-gradient(circle, rgba(148, 163, 184, 0.28) 1px, transparent 0);
+  background-image: var(--body-after-background);
   background-size: 80px 80px, 80px 80px, 80px 80px;
   background-position: 0 0, 0 0, 40px 40px;
-  opacity: 0.1;
-  mix-blend-mode: screen;
+  opacity: var(--body-after-opacity);
+  mix-blend-mode: var(--body-after-mix-blend);
   mask-image: radial-gradient(circle at 50% 32%, rgba(0, 0, 0, 0.82), rgba(0,0,0,0.1) 72%);
   -webkit-mask-image: radial-gradient(circle at 50% 32%, rgba(0, 0, 0, 0.82), rgba(0,0,0,0.1) 72%);
   z-index: -1;
@@ -95,6 +180,172 @@ body::after {
 ::selection {
   background: rgba(255, 115, 245, 0.45);
   color: #05021a;
+}
+
+body[data-theme="light"] ::selection {
+  background: rgba(244, 169, 255, 0.4);
+  color: #1a0f38;
+}
+
+.site-header__panel {
+  background: var(--header-panel-bg);
+  border-color: var(--header-panel-border);
+  box-shadow: var(--header-panel-shadow);
+  transition: background 0.4s ease, border-color 0.4s ease, box-shadow 0.4s ease;
+}
+
+.site-header__halo {
+  background: var(--header-halo);
+  transition: opacity 0.4s ease;
+}
+
+.site-header__glint {
+  background: var(--header-glint);
+  transition: opacity 0.4s ease;
+}
+
+.site-header__brand-name {
+  color: var(--header-brand-name);
+  transition: color 0.3s ease;
+}
+
+.site-header__brand-title {
+  color: var(--header-brand-title);
+  transition: color 0.3s ease;
+}
+
+.site-header__initials {
+  background: var(--header-initials-bg);
+  color: var(--header-initials-text);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.08);
+  transition: background 0.4s ease, color 0.4s ease, box-shadow 0.4s ease;
+}
+
+.site-header__initials-text {
+  color: currentColor;
+}
+
+.site-header__nav-link {
+  background: var(--header-nav-bg);
+  color: var(--header-nav-text);
+  transition: background 0.3s ease, color 0.3s ease, box-shadow 0.3s ease;
+}
+
+.site-header__nav-link:hover {
+  background: var(--header-nav-hover-bg);
+  color: var(--header-nav-hover-text);
+}
+
+.site-header__cta {
+  background: var(--header-cta-bg);
+  border-color: var(--header-cta-border);
+  box-shadow: var(--header-cta-shadow);
+  color: var(--header-cta-text);
+  transition: background 0.4s ease, border-color 0.4s ease, color 0.4s ease, box-shadow 0.4s ease;
+}
+
+.site-header__cta:hover {
+  background: var(--header-cta-hover-bg);
+  border-color: var(--header-cta-hover-border);
+  box-shadow: var(--header-cta-hover-shadow);
+  color: var(--header-cta-hover-text);
+}
+
+.site-header__toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  border: 1px solid var(--header-toggle-border);
+  border-radius: 9999px;
+  padding: 0.4rem 0.9rem;
+  background: var(--header-toggle-bg);
+  color: var(--header-toggle-text);
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  transition: background 0.3s ease, border-color 0.3s ease, color 0.3s ease, box-shadow 0.3s ease;
+  backdrop-filter: blur(10px);
+  -webkit-backdrop-filter: blur(10px);
+}
+
+.site-header__toggle:hover {
+  background: var(--header-toggle-hover-bg);
+  border-color: var(--header-toggle-hover-border);
+}
+
+.site-header__toggle-icon {
+  font-size: 0.95rem;
+  line-height: 1;
+}
+
+.site-header__toggle-label {
+  display: inline-flex;
+  align-items: center;
+}
+
+body[data-theme="light"] .text-white,
+body[data-theme="light"] .text-slate-50\/95,
+body[data-theme="light"] .text-slate-100 {
+  color: var(--light-text-primary) !important;
+}
+
+body[data-theme="light"] .text-slate-100\/90,
+body[data-theme="light"] .text-slate-200,
+body[data-theme="light"] .text-slate-200\/90 {
+  color: var(--light-text-secondary) !important;
+}
+
+body[data-theme="light"] .text-slate-100\/85,
+body[data-theme="light"] .text-slate-100\/75,
+body[data-theme="light"] .text-slate-100\/70 {
+  color: var(--light-text-muted) !important;
+}
+
+body[data-theme="light"] .text-fuchsia-100,
+body[data-theme="light"] .text-fuchsia-100\/70,
+body[data-theme="light"] .text-fuchsia-100\/80,
+body[data-theme="light"] .text-fuchsia-100\/90,
+body[data-theme="light"] .text-fuchsia-200\/80 {
+  color: var(--light-accent-pink) !important;
+}
+
+body[data-theme="light"] .text-emerald-100 {
+  color: var(--light-accent-emerald) !important;
+}
+
+body[data-theme="light"] .bg-white\/5,
+body[data-theme="light"] .bg-white\/10,
+body[data-theme="light"] .bg-white\/[0\.08],
+body[data-theme="light"] .bg-white\/[0\.12] {
+  background-color: rgba(255, 255, 255, 0.78) !important;
+}
+
+body[data-theme="light"] .hover\:bg-white\/10:hover,
+body[data-theme="light"] .hover\:bg-white\/[0\.12]:hover {
+  background-color: rgba(255, 255, 255, 0.88) !important;
+}
+
+body[data-theme="light"] .bg-[#070a1d]\/90,
+body[data-theme="light"] .bg-[#070c26] {
+  background-color: rgba(255, 255, 255, 0.88) !important;
+  color: var(--light-text-primary);
+}
+
+body[data-theme="light"] .border-white\/15,
+body[data-theme="light"] .border-white\/20,
+body[data-theme="light"] .border-white\/25,
+body[data-theme="light"] .border-white\/30,
+body[data-theme="light"] .border-white\/35,
+body[data-theme="light"] .border-white\/40,
+body[data-theme="light"] .border-white\/45,
+body[data-theme="light"] .border-white\/55,
+body[data-theme="light"] .border-white\/60 {
+  border-color: rgba(168, 85, 247, 0.3) !important;
+}
+
+body[data-theme="light"] .hover\:border-white\/55:hover,
+body[data-theme="light"] .hover\:border-white\/60:hover {
+  border-color: rgba(124, 58, 237, 0.45) !important;
 }
 
 @media (pointer: fine) {

--- a/components/common/theme-toggle.tsx
+++ b/components/common/theme-toggle.tsx
@@ -1,0 +1,98 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+
+const STORAGE_KEY = "portfolio-theme";
+
+type Theme = "dark" | "light";
+
+type ThemeToggleProps = {
+  className?: string;
+};
+
+function resolvePreferredTheme(): Theme {
+  if (typeof window === "undefined") {
+    return "dark";
+  }
+
+  const stored = window.localStorage.getItem(STORAGE_KEY);
+  if (stored === "light" || stored === "dark") {
+    return stored;
+  }
+
+  return window.matchMedia("(prefers-color-scheme: dark)").matches
+    ? "dark"
+    : "light";
+}
+
+export function ThemeToggle({ className }: ThemeToggleProps) {
+  const [theme, setTheme] = useState<Theme>(() => resolvePreferredTheme());
+
+  useEffect(() => {
+    const preferred = resolvePreferredTheme();
+    setTheme(preferred);
+  }, []);
+
+  useEffect(() => {
+    if (typeof document === "undefined") {
+      return;
+    }
+
+    document.documentElement.dataset.theme = theme;
+    document.body.dataset.theme = theme;
+    window.localStorage.setItem(STORAGE_KEY, theme);
+  }, [theme]);
+
+  useEffect(() => {
+    if (typeof window === "undefined") {
+      return;
+    }
+
+    const mediaQuery = window.matchMedia("(prefers-color-scheme: dark)");
+
+    const handleChange = () => {
+      const stored = window.localStorage.getItem(STORAGE_KEY);
+      if (stored !== "light" && stored !== "dark") {
+        setTheme(mediaQuery.matches ? "dark" : "light");
+      }
+    };
+
+    if (typeof mediaQuery.addEventListener === "function") {
+      mediaQuery.addEventListener("change", handleChange);
+      return () => mediaQuery.removeEventListener("change", handleChange);
+    }
+
+    // Fallback for older browsers
+    if (typeof mediaQuery.addListener === "function") {
+      mediaQuery.addListener(handleChange);
+      return () => mediaQuery.removeListener(handleChange);
+    }
+
+    return undefined;
+  }, []);
+
+  const label = useMemo(
+    () => (theme === "dark" ? "Switch to light mode" : "Switch to dark mode"),
+    [theme],
+  );
+
+  return (
+    <button
+      type="button"
+      onClick={() =>
+        setTheme((current) => (current === "dark" ? "light" : "dark"))
+      }
+      className={["site-header__toggle", className].filter(Boolean).join(" ")}
+      aria-label={label}
+      role="switch"
+      aria-checked={theme === "light"}
+    >
+      <span aria-hidden className="site-header__toggle-icon">
+        {theme === "dark" ? "🌙" : "🌞"}
+      </span>
+      <span className="site-header__toggle-label">
+        {theme === "dark" ? "Dark" : "Light"} mode
+      </span>
+    </button>
+  );
+}

--- a/components/layout/site-header.tsx
+++ b/components/layout/site-header.tsx
@@ -1,5 +1,6 @@
 import type { NavItem, Profile } from "@/data/portfolio";
 import { getInitials } from "@/lib/get-initials";
+import { ThemeToggle } from "@/components/common/theme-toggle";
 
 type SiteHeaderProps = {
   profile: Profile;
@@ -11,7 +12,7 @@ type NavLinkProps = NavItem;
 function NavLink({ href, label }: NavLinkProps) {
   return (
     <a
-      className="group relative  inline-flex items-center overflow-hidden px-4 py-2 text-sm text-fuchsia-100 font-semibold transition-all duration-300 hover:text-white rounded-lg hover:bg-linear-65 hover:from-fuchsia-500/25 hover:to-sky-400/25 hover:shadow-white/20 hover:shadow-lg"
+      className="site-header__nav-link group relative inline-flex items-center overflow-hidden rounded-lg px-4 py-2 text-sm font-semibold transition-all duration-300 hover:shadow-white/20 hover:shadow-lg"
       href={href}
       style={{
         backdropFilter: 'blur(10px)',
@@ -29,23 +30,23 @@ export function SiteHeader({ profile, navItems }: SiteHeaderProps) {
 
   return (
     <header className="fixed top-0 left-0 right-0 z-50 w-full pt-4">
-      <div className="relative isolate mx-auto flex w-full max-w-5xl items-center justify-between gap-6 overflow-hidden rounded-full border border-white/25 bg-white/10 px-6 py-3 shadow-[0_55px_110px_-65px_rgba(244,114,182,0.75)] backdrop-blur sm:mx-6 lg:mx-auto">
+      <div className="site-header__panel relative isolate mx-auto flex w-full max-w-5xl items-center justify-between gap-6 overflow-hidden rounded-full border px-6 py-3 backdrop-blur sm:mx-6 lg:mx-auto">
         <span
           aria-hidden
-          className="pointer-events-none absolute inset-0 -z-20 bg-[radial-gradient(circle_at_top,_rgba(244,114,182,0.45),_transparent_65%)] opacity-75 transition-opacity duration-700 group-hover:opacity-95"
+          className="site-header__halo pointer-events-none absolute inset-0 -z-20 opacity-75 transition-opacity duration-700"
         />
         <span
           aria-hidden
-          className="pointer-events-none absolute inset-0 -z-30 bg-gradient-to-r from-white/20 via-transparent to-white/20"
+          className="site-header__glint pointer-events-none absolute inset-0 -z-30"
         />
 
-  <a className="flex items-center gap-4" href="#top" data-brand-link>
-          <div className="flex h-11 w-11 items-center justify-center rounded-full bg-white/10 text-sm font-semibold text-white">
-            <span className="text-xs tracking-[0.2em] text-slate-100">{initials}</span>
+        <a className="site-header__brand-link flex items-center gap-4" href="#top" data-brand-link>
+          <div className="site-header__initials flex h-11 w-11 items-center justify-center rounded-full text-sm font-semibold">
+            <span className="site-header__initials-text text-xs tracking-[0.2em]">{initials}</span>
           </div>
-          <div className="hidden text-sm leading-tight text-fuchsia-100/80 sm:block">
-            <p className="font-display text-base font-semibold text-white">{profile.name}</p>
-            <p>{profile.title}</p>
+          <div className="site-header__brand-copy hidden text-sm leading-tight sm:block">
+            <p className="site-header__brand-name font-display text-base font-semibold">{profile.name}</p>
+            <p className="site-header__brand-title">{profile.title}</p>
           </div>
         </a>
 
@@ -55,12 +56,15 @@ export function SiteHeader({ profile, navItems }: SiteHeaderProps) {
           ))}
         </nav>
 
-        <a
-          className="relative inline-flex items-center gap-2 rounded-full border border-white/35 bg-gradient-to-r from-fuchsia-400/25 via-transparent to-sky-400/25 px-5 py-2 text-sm font-medium text-white transition-all duration-500 hover:border-white/55 hover:text-white"
-          href={`mailto:${profile.email}`}
-        >
-          <span className="relative">Let's talk</span>
-        </a>
+        <div className="site-header__actions flex items-center gap-3">
+          <ThemeToggle />
+          <a
+            className="site-header__cta relative inline-flex items-center gap-2 rounded-full border px-5 py-2 text-sm font-medium transition-all duration-500"
+            href={`mailto:${profile.email}`}
+          >
+            <span className="relative">Let's talk</span>
+          </a>
+        </div>
       </div>
     </header>
   );


### PR DESCRIPTION
## Summary
- add a client-side theme toggle in the site header that persists the selected mode and respects system preferences
- expose theme-aware design tokens and restyle the header elements to work in both dark and light modes
- introduce a bright light theme palette with readable text overrides and surface adjustments across the app

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d025fc5168832b90754c366c677ef6